### PR TITLE
workflow test

### DIFF
--- a/.github/workflows/check-cherry-pick.yml
+++ b/.github/workflows/check-cherry-pick.yml
@@ -1,6 +1,6 @@
 name: "Check cherry-picks"
 on:
-  pull_request:
+  pull_request_target:
 
 env:
   PICKABLE_BRANCHES: master staging
@@ -8,11 +8,14 @@ env:
 jobs:
   check:
     runs-on: ubuntu-latest
+    #if: github.repository_owner == 'NixOS'
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - run: |
+        problem=0
+
         git rev-list '${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}' \
           -E -i --grep="cherry.*[0-9a-f]{40}" \
           | while read commit_sha ; do
@@ -27,17 +30,21 @@ jobs:
             | egrep -oi -m1 '[0-9a-f]{40}'
           )
           if [ "$?" = "0" ] ; then
-            echo "⁉ Couldn't locate commit hash in message"
+            echo "  ⁉ Couldn't locate commit hash in message"
             continue
           fi
 
           for $picked_branch in $PICKABLE_BRANCHES ; do
             if git merge-base --is-ancestor "$original_commit_sha" "picked_branch" ; then
-              echo "✔ $original_commit_sha present in branch $picked_branch"
+              echo "  ✔ $original_commit_sha present in branch $picked_branch"
+
 
               continue 2
             fi
           done
 
-          echo "✘ $original_commit_sha not found in any pickable branch"
+          echo "  ✘ $original_commit_sha not found in any pickable branch"
+          problem=1
         done
+
+        exit $problem

--- a/.github/workflows/check-cherry-pick.yml
+++ b/.github/workflows/check-cherry-pick.yml
@@ -1,0 +1,43 @@
+name: "Check cherry-picks"
+on:
+  pull_request:
+
+env:
+  PICKABLE_BRANCHES: master staging
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - run: |
+        git rev-list '${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}' \
+          -E -i --grep="cherry.*[0-9a-f]{40}" \
+          | while read commit_sha ; do
+
+          echo "================================================="
+          git rev-list --max-count=1 --format=medium "$commit_sha"
+          echo "-------------------------------------------------"
+
+          original_commit_sha=$(
+            git rev-list --max-count=1 --format=format:%B "$commit_sha" \
+            | egrep -i -m1 "cherry.*[0-9a-f]{40}" \
+            | egrep -oi -m1 '[0-9a-f]{40}'
+          )
+          if [ "$?" = "0" ] ; then
+            echo "⁉ Couldn't locate commit hash in message"
+            continue
+          fi
+
+          for $picked_branch in $PICKABLE_BRANCHES ; do
+            if git merge-base --is-ancestor "$original_commit_sha" "picked_branch" ; then
+              echo "✔ $original_commit_sha present in branch $picked_branch"
+
+              continue 2
+            fi
+          done
+
+          echo "✘ $original_commit_sha not found in any pickable branch"
+        done


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
